### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://vikasagarwal.visualstudio.com/fafc75b9-7cf9-488b-996b-d1c5730a0ad9/330063f9-47cb-49fc-8f60-203f0c977f99/_apis/work/boardbadge/53309f7f-2a72-42d7-95cf-e6b4b263a8fb)](https://vikasagarwal.visualstudio.com/fafc75b9-7cf9-488b-996b-d1c5730a0ad9/_boards/board/t/330063f9-47cb-49fc-8f60-203f0c977f99/Microsoft.RequirementCategory)
 test bgfgf


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://vikasagarwal.visualstudio.com/fafc75b9-7cf9-488b-996b-d1c5730a0ad9/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.